### PR TITLE
feat: add conversion process for category : `network_connection`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,9 @@
 # 変更点
 
+## v2.16.0 [2024/07/30]
+
+- 現在、Windowsビルトインの`Security 5156`イベントの`category: network_connection`ルールを作成している。 #10 (@fukusuket)
+
 ## v2.16.0 [2024/06/25]
 
 - `.yml`ファイル内に複数のルールを持つSigma相関ルールの変換に対応した。 #9 (@fukusuket)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## v2.16.0 [2024/07/30]
+
+- We are now creating built-in Windows `Security 5156` rules for `category: network_connection` rules. Before, the rules would only detect `Sysmon 3` events. #10 (@fukusuket) 
+
 ## v2.16.0 [2024/06/25]
 
 - Support for converting Sigma correlation rules with multiple rules inside a single `.yml` file. #9 (@fukusuket)

--- a/windows-audit.yaml
+++ b/windows-audit.yaml
@@ -40,6 +40,14 @@ logsources:
         rewrite:
             product: windows
             service: security
+    network_connection:
+        category: network_connection
+        product: windows
+        conditions:
+            EventID: 5156
+        rewrite:
+            product: windows
+            service: security
 fieldmappings_process:
     Image: NewProcessName
     ProcessId: NewProcessId
@@ -54,3 +62,10 @@ fieldmappings_registry:
     Details: NewValue
     EventType: OperationType
     TargetObject: ObjectName
+fieldmappings_network:
+    Image: Application
+    Initiated: Direction
+    SourceIp: SourceAddress
+    DestinationIp: DestAddress
+    DestinationPort: DestPort
+    Protocol: Protocol


### PR DESCRIPTION
## What Changed
- Closed #3 
- Improved checking of incompatible rules
  - If the `selection` block by itself is incompatible, it is not converted. 

### Incompatibility rule check before this PR
- https://github.com/Yamato-Security/hayabusa-rules/pull/445#issuecomment-1616354686

I would appreciate it if you could check it out when you have time🙏