### PR TITLE
ignore wmi rule

### DIFF
--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -2,4 +2,5 @@
 #ec19ebab-72dc-40e1-9728-4c0b805d722c # Tamper Windows Defender - PSClassic
 #14c71865-6cd3-44ae-adaa-1db923fae5f2 # Tamper Windows Defender - ScriptBlockLogging
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
-#0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules
+
+0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules and the rule is not correct to begin with so will not catch anything.

--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -3,4 +3,4 @@
 #14c71865-6cd3-44ae-adaa-1db923fae5f2 # Tamper Windows Defender - ScriptBlockLogging
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
 
-0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules and the rule is not correct to begin with so will not catch anything.
+0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules.


### PR DESCRIPTION
This rule does not work with the WMI logs as it is looking for multiple Event IDs at the same time:
```
detection:
    wmi_event:
        EventID: 5861
        Channel: Microsoft-Windows-WMI-Activity/Operational
    selection:
        EventID:
            - 19
            - 20
            - 21
    condition: wmi_event and selection
```

This sysmon version of this rule works:
```

detection:
    wmi_event:
        EventID:
            - 19
            - 20
            - 21
        Channel: Microsoft-Windows-Sysmon/Operational
    selection:
        EventID:
            - 19
            - 20
            - 21
    condition: wmi_event and selection
```
However, we already have Hayabusa rules for WMI events that will handle it better, so I think we should just ignore this rule.