### PR TITLE
ignore syntax error rule

### DIFF
--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -4,3 +4,4 @@
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
 
 0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules.
+7477881c-ec3b-49d6-aced-7255944e5c59 # Workaround for https://github.com/Yamato-Security/hayabusa/issues/1677


### PR DESCRIPTION
@fukusuket I confirmed that the slack notification for when rule parsing fails works now. Thanks so much!!

<img width="268" height="154" alt="Screenshot 2025-08-14 at 5 56 13 AM" src="https://github.com/user-attachments/assets/0bac4a6c-2bb2-49ba-90a1-50f9239805d3" />

Let's add this rule back until we support `base64` modifiers.