### PR TITLE
chg: update ignore UUID list with additional entry

### DIFF
--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -4,3 +4,4 @@
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
 
 0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules.
+d80d5c81-04ba-45b4-84e4-92eba40e0ad3 #Arbitrary DLL or Csproj Code Execution Via Dotnet.EXE

--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -4,4 +4,4 @@
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
 
 0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules.
-d80d5c81-04ba-45b4-84e4-92eba40e0ad3 #Arbitrary DLL or Csproj Code Execution Via Dotnet.EXE
+d80d5c81-04ba-45b4-84e4-92eba40e0ad3 # Arbitrary DLL or Csproj Code Execution Via Dotnet.EXE


### PR DESCRIPTION
Until the following feature of Hayabusa is released, the Actions will fail, so we will temporarily exclude the UUID.
- https://github.com/Yamato-Security/hayabusa-rules/actions/runs/18477065224
- https://github.com/Yamato-Security/hayabusa/actions/runs/18481207385

I’d appreciate it if you could check it when you have time🙏