### PR TITLE
chg: add ignore uuid

### DIFF
--- a/ignore-uuid-list.txt
+++ b/ignore-uuid-list.txt
@@ -4,3 +4,4 @@
 #30edb182-aa75-42c0-b0a9-e998bb29067c # Potential AMSI Bypass Via .NET Reflection
 
 0f06a3a5-6a09-413f-8743-e6cf35561297 # Looks for any Sysmon WMI event but is better handled with Hayabusa rules.
+c598cc0c-9e70-4852-b9eb-8921af79f598 # Hacktool - EDR-Freeze Execution


### PR DESCRIPTION
I'm temporarily excluding the following rules because they fail to parse without the Author (Optional) field.
- https://github.com/Yamato-Security/hayabusa-rules/actions/runs/18696314934/job/53314624773
- https://github.com/SigmaHQ/sigma/pull/5657
- https://github.com/SigmaHQ/sigma/blob/f69ac5c345e6a21dc50bfbf5bb09e19bfc8a3235/rules/windows/process_creation/proc_creation_win_hktl_edr_freeze.yml

I’d appreciate it if you could check it when you have time🙏